### PR TITLE
Add mcollective-plugins submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "apt"]
 	path = apt
 	url = https://github.com/evolvingweb/puppet-apt
+[submodule "mcollective-plugins"]
+	path = mcollective-plugins
+	url = git://github.com/puppetlabs/mcollective-plugins.git


### PR DESCRIPTION
Add mcollective-plugins submodule in preparation for the mcollective puppet module.

Signed-off-by: Leif Madsen leif@leifmadsen.com
